### PR TITLE
Checks whether docker supports the --gpus option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,12 @@ ROUSSELLE2012?=_extras/comparisons/methods/2012_rousselle_nlm
 KALANTARI2015?=_extras/comparisons/methods/2015_kalantari_lbf
 BITTERLI2016?=_extras/comparisons/methods/nfor_fromdocker
 
+# Checks whether docker version supports the --gpus option
+check_docker_version:
+	./scripts/check_docker_version.sh
+
 # Install the required extension for CUDA on Docker
-nvidia_docker:
+nvidia_docker: check_docker_version
 	./scripts/install_nvidia_docker.sh
 
 # To facilitate environment setup, build and use this dockerfile

--- a/scripts/check_docker_version.sh
+++ b/scripts/check_docker_version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+DOCKER_MINIMUM_REQUIRED_VERSION=19.03
+
+# Copied from https://stackoverflow.com/a/24067243
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+
+current_docker_version=`docker version --format '{{.Server.Version}}'`
+if version_gt $DOCKER_MINIMUM_REQUIRED_VERSION $current_docker_version; then
+     echo "Docker version >=${DOCKER_MINIMUM_REQUIRED_VERSION} required for for the --gpus option."
+fi


### PR DESCRIPTION
## Overview

Checks whether `docker` supports the `--gpus` option
* Adds *scripts/check_docker_version.sh*
* Adds `check_docker_version` `make` target

Related to #3 

### Demo
n/a

### Notes
n/a

## Testing Instructions
n/a