### PR TITLE
Use --gpus or --cpus depending on docker version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ and run it:
 
     If all goes well, this will launch a shell on the Docker instance and you
     should not have to worry about configuring the Linux or Python environment.
+	Notice that nvidia supports `docker >= 19.03`, so if your version is outdated,
+	gpu support will be disabled.
 
 4. (optional) From within the running Docker instance, run the package's tests:
 


### PR DESCRIPTION
## Overview
Update makefile to use --gpus or --cpus based on the docker version. Docker only supports --gpus from version 19.03

### Notes
Solves #3 

## Testing Instructions
`make docker_run` should use `--gpus` only if docker >= 19.03
