### PR TITLE
Fix some broken urls in dockerfiles

### DIFF
--- a/dockerfiles/cpu-sbmc.dockerfile
+++ b/dockerfiles/cpu-sbmc.dockerfile
@@ -65,7 +65,7 @@ RUN cd 2016_bitterli_nfor && mkdir build && cd build && cmake .. && make -j 4
 
 
 # Install Halide
-RUN wget -O halide.tgz https://github.com/halide/Halide/releases/download/release_2019_08_27/halide-linux-64-gcc53-800-65c26cba6a3eca2d08a0bccf113ca28746012cc3.tgz
+RUN wget -O halide.tgz https://github.com/halide/Halide/releases/download/v8.0.0/halide-linux-64-gcc53-800-65c26cba6a3eca2d08a0bccf113ca28746012cc3.tgz
 RUN tar zvxf halide.tgz
 RUN rm -rf halide.tgz
 ENV HALIDE_DISTRIB_DIR /sbmc_app/halide
@@ -73,7 +73,7 @@ ENV HALIDE_DISTRIB_DIR /sbmc_app/halide
 
 # Python Environment ----------------------------------------------------------
 RUN curl -o /sbmc_app/anaconda.sh -O \
-        https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+        https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh && \
     sha256sum /sbmc_app/anaconda.sh && \
     chmod a+x /sbmc_app/anaconda.sh && \
     /sbmc_app/anaconda.sh -b -p /sbmc_app/anaconda

--- a/dockerfiles/cuda-sbmc.dockerfile
+++ b/dockerfiles/cuda-sbmc.dockerfile
@@ -90,7 +90,7 @@ RUN cd 2016_bitterli_nfor && mkdir build && cd build && cmake .. && make -j 4
 
 
 # Install Halide
-RUN wget -O halide.tgz https://github.com/halide/Halide/releases/download/release_2019_08_27/halide-linux-64-gcc53-800-65c26cba6a3eca2d08a0bccf113ca28746012cc3.tgz
+RUN wget -O halide.tgz https://github.com/halide/Halide/releases/download/v8.0.0/halide-linux-64-gcc53-800-65c26cba6a3eca2d08a0bccf113ca28746012cc3.tgz
 RUN tar zvxf halide.tgz
 RUN rm -rf halide.tgz
 ENV HALIDE_DISTRIB_DIR /sbmc_app/halide
@@ -98,7 +98,7 @@ ENV HALIDE_DISTRIB_DIR /sbmc_app/halide
 
 # Python Environment ----------------------------------------------------------
 RUN curl -o /sbmc_app/anaconda.sh -O \
-        https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+        https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh && \
     sha256sum /sbmc_app/anaconda.sh && \
     chmod a+x /sbmc_app/anaconda.sh && \
     /sbmc_app/anaconda.sh -b -p /sbmc_app/anaconda


### PR DESCRIPTION
## Overview

When I try to quick start the project, I have :
- A 404 error on the halide `release_2019_08_27` URL and I replace it, by the tag of the 2019-08-27 release (probably due to the recent release of v10). 
- A python version error. Python 3.8 is installed by default and this is not valid for others packages versions (`torchvision==0.4.0 -> python[version='>=2.7,<2.8.0a0|>=3.6,<3.7.0a0|>=3.5,<3.6.0a0|>=3.7,<3.8.0a0']`).

## Testing Instructions

To test my PR, just normally follow the quick start
